### PR TITLE
Optimize SwitchModule and don't open tab if open

### DIFF
--- a/ftplugin/clean.vim
+++ b/ftplugin/clean.vim
@@ -36,10 +36,21 @@ if !exists("*s:CleanSwitchModule")
   function s:CleanSwitchModule(cmd)
     let basename = expand("%:r")
     let filename = basename . (expand('%:e') == 'icl' ? '.dcl' : '.icl')
-    let modname = substitute(basename, '/', '.', 'g')
-    let header = expand('%:e') == 'icl' ? 'definition' : 'implementation'
+    for tabNo in range(1, tabpagenr("$"))
+      for bufInTab in tabpagebuflist(tabNo)
+         if bufname(bufInTab) == filename
+           exec 'tabn ' . tabNo
+           return
+         endif
+      endfor
+    endfor
+
+    "Not open in a tab, thus we spawn a new one
     exec a:cmd . ' ' . filename
+
     if g:clean_autoheader && !filereadable(filename)
+      let modname = substitute(basename, '/', '.', 'g')
+      let header = expand('%:e') == 'icl' ? 'definition' : 'implementation'
       exec 'normal i' . header . ' module ' . modname . "\<CR>\<CR>\<Esc>"
     endif
   endfunction


### PR DESCRIPTION
This moves some functionality within the if statements for speed.
Also, it checks whether the file is already open, if so it will switch
to the file instead of opening it again. This approach is a bit crude
and might not word with relative paths compared to absolute ones.
However, this works in most use cases and doesn't break anything.

It would be interesting to also focus the correct buffer if it is in a
split for example.